### PR TITLE
🔀 :: (#70) 피드 전체 불러오기 API 에러 해결

### DIFF
--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedElement.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedElement.java
@@ -17,8 +17,9 @@ public class FeedElement {
     private final LocalDateTime createdAt;
     private final String profile;
     private final String name;
-    private final Integer likeCount;
-    private final Integer commentCount;
+    private final String type;
+    private final Long likeCount;
+    private final Long commentCount;
     private final Boolean isMine;
     private final Boolean isLike;
     private final List<String> attachmentsUrl;

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedList.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedList.java
@@ -12,7 +12,8 @@ public class FeedList {
     private final UUID feedId;
     private final UUID userId;
     private final String content;
+    private final String type;
     private final LocalDateTime createdAt;
-    private final Integer likeCount;
-    private final Integer commentCount;
+    private final Long likeCount;
+    private final Long commentCount;
 }

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -94,7 +94,7 @@ public class FeedApiImpl implements FeedApi {
                 .map(feed -> {
                     User user = hashMap.getOrDefault(feed.getUserId(), defaultUser);
                     FeedLike feedLike = queryFeedLikeSpi.queryFeedLikeByFeedId(feed.getFeedId());
-                    Boolean isLike = feedLike.getId() != null && feedLike.getUserId().equals(currentUserId);
+                    Boolean isLike = feedLike != null && feedLike.getUserId().equals(currentUserId);
                     Boolean isMine = user.getId() != null && feed.getUserId().equals(currentUserId);
                     List<String> attachmentsUrl = queryFeedImageSpi.queryAllAttachmentsUrl(feed.getFeedId());
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -103,7 +103,7 @@ public class FeedApiImpl implements FeedApi {
                     User user = hashMap.getOrDefault(feed.getUserId(), defaultUser);
                     FeedLike feedLike = queryFeedLikeSpi.queryFeedLikeByFeedId(feed.getFeedId());
                     Boolean isLike = feedLike != null && feedLike.getUserId().equals(currentUserId);
-                    Boolean isMine = user != null && !feed.getUserId().equals(currentUserId);
+                    Boolean isMine = user != null && feed.getUserId().equals(currentUserId);
                     List<String> attachmentsUrl = queryFeedImageSpi.queryAllAttachmentsUrl(feed.getFeedId());
 
                     return FeedElement.builder()

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -8,8 +8,16 @@ import com.xquare.v1servicefeed.feed.Feed;
 import com.xquare.v1servicefeed.feed.api.FeedApi;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
-import com.xquare.v1servicefeed.feed.api.dto.response.*;
-import com.xquare.v1servicefeed.feed.spi.*;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryElement;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryListResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedElement;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
+import com.xquare.v1servicefeed.feed.spi.CommandFeedImageSpi;
+import com.xquare.v1servicefeed.feed.spi.CommandFeedSpi;
+import com.xquare.v1servicefeed.feed.spi.QueryCategorySpi;
+import com.xquare.v1servicefeed.feed.spi.QueryFeedImageSpi;
+import com.xquare.v1servicefeed.feed.spi.QueryFeedSpi;
 import com.xquare.v1servicefeed.feedlike.FeedLike;
 import com.xquare.v1servicefeed.feedlike.spi.QueryFeedLikeSpi;
 import com.xquare.v1servicefeed.user.User;
@@ -17,7 +25,6 @@ import com.xquare.v1servicefeed.user.exception.InvalidRoleException;
 import com.xquare.v1servicefeed.user.spi.FeedUserSpi;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +90,8 @@ public class FeedApiImpl implements FeedApi {
 
     @Override
     public FeedListResponse getAllFeed(UUID categoryId) {
-        List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
+        Category category = queryCategorySpi.queryCategoryById(categoryId);
+        List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(category.getCategoryId());
         Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
         User defaultUser = User.builder().name("").profileFileName("").build();

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -95,7 +95,7 @@ public class FeedApiImpl implements FeedApi {
                     User user = hashMap.getOrDefault(feed.getUserId(), defaultUser);
                     FeedLike feedLike = queryFeedLikeSpi.queryFeedLikeByFeedId(feed.getFeedId());
                     Boolean isLike = feedLike != null && feedLike.getUserId().equals(currentUserId);
-                    Boolean isMine = user.getId() != null && feed.getUserId().equals(currentUserId);
+                    Boolean isMine = user != null && !feed.getUserId().equals(currentUserId);
                     List<String> attachmentsUrl = queryFeedImageSpi.queryAllAttachmentsUrl(feed.getFeedId());
 
                     return FeedElement.builder()

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
@@ -1,8 +1,6 @@
 package com.xquare.v1servicefeed.feed.domain.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.xquare.v1servicefeed.configuration.annotation.Adapter;
 import com.xquare.v1servicefeed.feed.Feed;
@@ -68,8 +66,8 @@ public class FeedRepositoryAdapter implements FeedSpi {
                         feedEntity.content,
                         feedEntity.type,
                         feedEntity.createdAt,
-                        queryFeedLikeCount(),
-                        queryFeedCommentCount()
+                        feedLikeEntity.count(),
+                        commentEntity.count()
                 ))
                 .from(feedEntity)
                 .leftJoin(feedLikeEntity)
@@ -77,6 +75,7 @@ public class FeedRepositoryAdapter implements FeedSpi {
                 .leftJoin(commentEntity)
                 .on(feedEntity.id.eq(commentEntity.feed.id))
                 .where(feedEntity.categoryEntity.id.eq(categoryId))
+                .groupBy(feedEntity.id)
                 .orderBy(feedEntity.createdAt.desc())
                 .fetch();
 
@@ -91,20 +90,6 @@ public class FeedRepositoryAdapter implements FeedSpi {
                         .commentCount(feedListVO.getCommentCount())
                         .build())
                 .collect(Collectors.toList());
-    }
-
-    public JPQLQuery<Long> queryFeedLikeCount() {
-        return JPAExpressions
-                .select(feedLikeEntity.count())
-                .from(feedLikeEntity)
-                .where(feedLikeEntity.feed.id.eq(feedEntity.id));
-    }
-
-    public JPQLQuery<Long> queryFeedCommentCount() {
-        return JPAExpressions
-                .select(commentEntity.count())
-                .from(commentEntity)
-                .where(commentEntity.feed.id.eq(feedEntity.id));
     }
 
     @Override

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
@@ -1,6 +1,8 @@
 package com.xquare.v1servicefeed.feed.domain.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.xquare.v1servicefeed.configuration.annotation.Adapter;
 import com.xquare.v1servicefeed.feed.Feed;
@@ -64,9 +66,10 @@ public class FeedRepositoryAdapter implements FeedSpi {
                         feedEntity.id,
                         feedEntity.userId,
                         feedEntity.content,
+                        feedEntity.type,
                         feedEntity.createdAt,
-                        feedLikeEntity.feed.count().intValue(),
-                        commentEntity.feed.count().intValue()
+                        queryFeedLikeCount(),
+                        queryFeedCommentCount()
                 ))
                 .from(feedEntity)
                 .leftJoin(feedLikeEntity)
@@ -82,11 +85,26 @@ public class FeedRepositoryAdapter implements FeedSpi {
                         .feedId(feedListVO.getFeedId())
                         .userId(feedListVO.getUserId())
                         .content(feedListVO.getContent())
+                        .type(feedListVO.getType())
                         .createdAt(feedListVO.getCreatedAt())
                         .likeCount(feedListVO.getLikeCount())
                         .commentCount(feedListVO.getCommentCount())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public JPQLQuery<Long> queryFeedLikeCount() {
+        return JPAExpressions
+                .select(feedLikeEntity.count())
+                .from(feedLikeEntity)
+                .where(feedLikeEntity.feed.id.eq(feedEntity.id));
+    }
+
+    public JPQLQuery<Long> queryFeedCommentCount() {
+        return JPAExpressions
+                .select(commentEntity.count())
+                .from(commentEntity)
+                .where(commentEntity.feed.id.eq(feedEntity.id));
     }
 
     @Override

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/vo/FeedListVO.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/vo/FeedListVO.java
@@ -12,15 +12,17 @@ public class FeedListVO {
     private final UUID feedId;
     private final UUID userId;
     private final String content;
+    private final String type;
     private final LocalDateTime createdAt;
-    private final Integer likeCount;
-    private final Integer commentCount;
+    private final Long likeCount;
+    private final Long commentCount;
 
     @QueryProjection
-    public FeedListVO(UUID feedId, UUID userId, String content, LocalDateTime createdAt, Integer likeCount, Integer commentCount) {
+    public FeedListVO(UUID feedId, UUID userId, String content, String type, LocalDateTime createdAt, Long likeCount, Long commentCount) {
         this.feedId = feedId;
         this.userId = userId;
         this.content = content;
+        this.type = type;
         this.createdAt = createdAt;
         this.likeCount = likeCount;
         this.commentCount = commentCount;

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
@@ -46,6 +46,10 @@ public class FeedLikeRepositoryAdapter implements FeedLikeSpi {
 
     @Override
     public FeedLike queryFeedLikeByFeedId(UUID feedId) {
+        FeedLikeEntity feedLikeEntity = getFeedLikeEntityByFeedId(feedId);
+        if (feedLikeEntity.getId() == null) {
+            return FeedLike.builder().build();
+        }
         return feedLikeMapper.entityToDomain(getFeedLikeEntityByFeedId(feedId));
     }
 
@@ -56,6 +60,6 @@ public class FeedLikeRepositoryAdapter implements FeedLikeSpi {
 
     private FeedLikeEntity getFeedLikeEntityByFeedId(UUID feedId) {
         return feedLikeRepository.findFeedLikeEntityByFeedId(feedId)
-                .orElseThrow(() -> FeedLikeNotFoundException.EXCEPTION);
+                .orElseGet(() -> FeedLikeEntity.builder().build());
     }
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
@@ -1,7 +1,6 @@
 package com.xquare.v1servicefeed.feedlike.domain.repository;
 
 import com.xquare.v1servicefeed.configuration.annotation.Adapter;
-import com.xquare.v1servicefeed.feed.domain.mapper.FeedMapper;
 import com.xquare.v1servicefeed.feedlike.FeedLike;
 import com.xquare.v1servicefeed.feedlike.domain.FeedLikeEntity;
 import com.xquare.v1servicefeed.feedlike.domain.mapper.FeedLikeMapper;
@@ -17,7 +16,6 @@ import java.util.UUID;
 public class FeedLikeRepositoryAdapter implements FeedLikeSpi {
 
     private final FeedLikeMapper feedLikeMapper;
-    private final FeedMapper feedMapper;
     private final FeedLikeRepository feedLikeRepository;
 
     @Override

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
@@ -45,9 +45,9 @@ public class FeedLikeRepositoryAdapter implements FeedLikeSpi {
     @Override
     public FeedLike queryFeedLikeByFeedId(UUID feedId) {
         FeedLikeEntity feedLikeEntity = feedLikeRepository.findFeedLikeEntityByFeedId(feedId)
-                .orElseGet(() -> FeedLikeEntity.builder().build());
+                .orElseGet(() -> null);
 
-        if (feedLikeEntity.getId() == null) return null;
+        if (feedLikeEntity == null) return null;
         return feedLikeMapper.entityToDomain(feedLikeEntity);
     }
 

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
@@ -45,7 +45,7 @@ public class FeedLikeRepositoryAdapter implements FeedLikeSpi {
     @Override
     public FeedLike queryFeedLikeByFeedId(UUID feedId) {
         FeedLikeEntity feedLikeEntity = feedLikeRepository.findFeedLikeEntityByFeedId(feedId)
-                .orElseGet(() -> null);
+                .orElse(null);
 
         if (feedLikeEntity == null) return null;
         return feedLikeMapper.entityToDomain(feedLikeEntity);

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/domain/repository/FeedLikeRepositoryAdapter.java
@@ -46,20 +46,15 @@ public class FeedLikeRepositoryAdapter implements FeedLikeSpi {
 
     @Override
     public FeedLike queryFeedLikeByFeedId(UUID feedId) {
-        FeedLikeEntity feedLikeEntity = getFeedLikeEntityByFeedId(feedId);
-        if (feedLikeEntity.getId() == null) {
-            return FeedLike.builder().build();
-        }
-        return feedLikeMapper.entityToDomain(getFeedLikeEntityByFeedId(feedId));
+        FeedLikeEntity feedLikeEntity = feedLikeRepository.findFeedLikeEntityByFeedId(feedId)
+                .orElseGet(() -> FeedLikeEntity.builder().build());
+
+        if (feedLikeEntity.getId() == null) return null;
+        return feedLikeMapper.entityToDomain(feedLikeEntity);
     }
 
     private FeedLikeEntity getFeedLikeEntityById(UUID feedLikeId) {
         return feedLikeRepository.findById(feedLikeId)
                 .orElseThrow(() -> FeedLikeNotFoundException.EXCEPTION);
-    }
-
-    private FeedLikeEntity getFeedLikeEntityByFeedId(UUID feedId) {
-        return feedLikeRepository.findFeedLikeEntityByFeedId(feedId)
-                .orElseGet(() -> FeedLikeEntity.builder().build());
     }
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/UserClient.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/UserClient.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.util.List;
 import java.util.UUID;
 
-@FeignClient(name = "UserClient", url = "${service.user.host}")
+@FeignClient(name = "UserClient", url = "${service.scheme}://${service.user.host}")
 public interface UserClient {
 
-    @GetMapping
-    UserInfoResponse getUserInfo(@RequestParam("id") List<UUID> userIds);
+    @GetMapping("/id")
+    UserInfoResponse getUserInfo(@RequestParam("userId") List<UUID> userIds);
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/dto/response/UserInfoResponse.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/dto/response/UserInfoResponse.java
@@ -2,12 +2,13 @@ package com.xquare.v1servicefeed.feign.client.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class UserInfoResponse {
 
-    private final List<UserInfoElement> users;
+    private List<UserInfoElement> users;
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/dto/response/UserInfoResponse.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/dto/response/UserInfoResponse.java
@@ -1,6 +1,5 @@
 package com.xquare.v1servicefeed.feign.client.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/feed-infrastructure/src/main/resources/application.yml
+++ b/feed-infrastructure/src/main/resources/application.yml
@@ -26,6 +26,10 @@ spring:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     hibernate:
       ddl-auto: validate
+    show-sql: ${sql.show}
+    properties:
+      hibernate:
+        format_sql: ${sql.format}
     open-in-view: false
 
   jackson:


### PR DESCRIPTION
피드 전체보기 API를 호출하면 아래와 같은 에러가 발생합니다.
- user NPE 발생
- feedLike가 없어서 에러 발생
- openFeign url 잘못으로 403 에러 발생
- type이 올바르지 않아 에러 발생
- count 쿼리로 인해 결과값이 제대로 나오지 않는 문제

close #70 