### PR TITLE
🔀 :: (#76) 댓글 관련 API 에러 해결

### DIFF
--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
@@ -70,11 +70,12 @@ public class CommentApiImpl implements CommentApi {
         List<UUID> userIdList = queryCommentSpi.queryAllCommentUserIdByFeed(feed);
         Map<UUID, User> map = commentUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
+        User defaultUser = User.builder().name("").profileFileName("").build();
 
         return queryCommentSpi.queryAllCommentByFeed(feed)
                 .stream()
                 .map(comment -> {
-                    User user = map.get(feed.getUserId());
+                    User user = map.getOrDefault(feed.getUserId(), defaultUser);
 
                     return CommentDomainElement.builder()
                             .commentId(comment.getId())

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/domain/repository/CommentRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/domain/repository/CommentRepositoryAdapter.java
@@ -84,7 +84,7 @@ public class CommentRepositoryAdapter implements CommentSpi {
                 ))
                 .from(commentEntity)
                 .where(commentEntity.feed.id.eq(feed.getId()))
-                .orderBy(feedEntity.createdAt.desc())
+                .orderBy(commentEntity.createAt.desc())
                 .fetch();
 
         return voList.stream()


### PR DESCRIPTION
댓글 전체 조회 API에서 orderBy절에서 'commentEntity.createAt.desc()' 잘못된 로직 수정
댁슬 전체 조회 API에서 defaultUser 설정으로 User NPE 발생 방지

close #76 