### PR TITLE
🔀 :: (#94) Feed 500에러 해결

### DIFF
--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
@@ -69,7 +69,7 @@ public class CommentApiImpl implements CommentApi {
         Feed feed = queryFeedSpi.queryFeedById(feedId);
         UUID currentUserId = securitySpi.getCurrentUserId();
 
-        Map<UUID, User> map = commentUserSpi.queryStudent().stream()
+        Map<UUID, User> map = commentUserSpi.queryAllUserByRole("").stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
         User defaultUser = User.builder().name("").profileFileName("").build();
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
@@ -69,7 +69,8 @@ public class CommentApiImpl implements CommentApi {
         Feed feed = queryFeedSpi.queryFeedById(feedId);
         UUID currentUserId = securitySpi.getCurrentUserId();
 
-        Map<UUID, User> map = commentUserSpi.queryAllUserByRole("").stream()
+        List<UUID> userIdList = queryCommentSpi.queryAllCommentUserIdByFeed(feed);
+        Map<UUID, User> map = commentUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
         User defaultUser = User.builder().name("").profileFileName("").build();
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -96,8 +96,7 @@ public class FeedApiImpl implements FeedApi {
 
     @Override
     public FeedListResponse getAllFeed(UUID categoryId) {
-        List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
-        Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()
+        Map<UUID, User> hashMap = feedUserSpi.queryAllUserByRole("").stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
         User defaultUser = User.builder().name("").profileFileName("").build();
         UUID currentUserId = securitySpi.getCurrentUserId();

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -96,7 +96,8 @@ public class FeedApiImpl implements FeedApi {
 
     @Override
     public FeedListResponse getAllFeed(UUID categoryId) {
-        Map<UUID, User> hashMap = feedUserSpi.queryAllUserByRole("").stream()
+        List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
+        Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
         User defaultUser = User.builder().name("").profileFileName("").build();
         UUID currentUserId = securitySpi.getCurrentUserId();

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/user/spi/CommentUserSpi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/user/spi/CommentUserSpi.java
@@ -1,6 +1,7 @@
 package com.xquare.v1servicefeed.user.spi;
 
 import com.xquare.v1servicefeed.user.User;
+import com.xquare.v1servicefeed.user.role.UserRole;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,5 +9,5 @@ import java.util.UUID;
 public interface CommentUserSpi {
     List<User> queryUserByIds(List<UUID> ids);
     void validateUserId(UUID userId, UUID currentUserId);
-    List<User> queryStudent();
+    List<User> queryAllUserByRole(String role);
 }

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/user/spi/FeedUserSpi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/user/spi/FeedUserSpi.java
@@ -2,6 +2,7 @@ package com.xquare.v1servicefeed.user.spi;
 
 import com.xquare.v1servicefeed.annotation.Spi;
 import com.xquare.v1servicefeed.user.User;
+import com.xquare.v1servicefeed.user.role.UserRole;
 
 import java.util.List;
 import java.util.UUID;
@@ -10,4 +11,5 @@ import java.util.UUID;
 public interface FeedUserSpi {
     List<User> queryUserByIds(List<UUID> ids);
     void validateUserId(UUID userId, UUID currentUserId);
+    List<User> queryAllUserByRole(String role);
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/domain/repository/CommentRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/domain/repository/CommentRepositoryAdapter.java
@@ -66,7 +66,10 @@ public class CommentRepositoryAdapter implements CommentSpi {
                 .selectFrom(commentEntity).distinct()
                 .leftJoin(feedEntity)
                 .on(feedEntity.id.eq(feed.getId()))
-                .where(feedEntity.id.eq(feed.getId()))
+                .where(
+                        feedEntity.id.eq(feed.getId()),
+                        feedEntity.type.eq("UKN").not()
+                )
                 .orderBy(commentEntity.createAt.desc())
                 .fetch();
 

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
@@ -100,7 +100,9 @@ public class FeedRepositoryAdapter implements FeedSpi {
                 .selectFrom(feedEntity).distinct()
                 .leftJoin(feedLikeEntity)
                 .on(feedEntity.id.eq(feedLikeEntity.feedEntity.id))
-                .where(categoryIdEq(categoryId))
+                .where(
+                        categoryIdEq(categoryId), feedEntity.type.eq("UKN").not()
+                )
                 .orderBy(feedEntity.createdAt.desc())
                 .fetch();
 

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/UserClient.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feign/client/UserClient.java
@@ -14,6 +14,6 @@ public interface UserClient {
     @GetMapping("/users/id")
     UserInfoResponse getUserInfo(@RequestParam("userId") List<UUID> userIds);
 
-    @GetMapping("/users/all")
-    UserInfoResponse getStudent();
+    @GetMapping("/users/role")
+    UserInfoResponse getStudent(@RequestParam(value = "roleName", required = false) String role);
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/user/domain/repository/UserRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/user/domain/repository/UserRepositoryAdapter.java
@@ -48,8 +48,8 @@ public class UserRepositoryAdapter implements FeedUserSpi, CommentUserSpi {
     }
 
     @Override
-    public List<User> queryStudent() {
-        List<UserInfoElement> userList = userClient.getStudent().getUsers();
+    public List<User> queryAllUserByRole(String role) {
+        List<UserInfoElement> userList = userClient.getStudent(role).getUsers();
 
         return userList.stream()
                 .map(userInfoElement -> User.builder()

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/user/domain/repository/UserRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/user/domain/repository/UserRepositoryAdapter.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RequiredArgsConstructor


### PR DESCRIPTION
close #94 

지금 현재 PR은 user정보를 가져오는 부분에서 에러가 발생하여 에러 해결 PR입니다.
에러가 발생한 이유는 다음과 같습니다.
- 기존에 User정보를 가져올 때 RequestParams로 UserId를 넘겨서 User정보를 가지고 왔습니다.
- 하지만 그 과정에서 Request 4096bytes 에러가 발생했습니다.
- URL 최대 길이가 4096bytes를 넘어서 발생한 문제였습니다.
- 그래서 지금 생각한 방법이 총 2개인데 우선 지금 당장 해결할 수 있는 문제로 해결했습니다.
- 1번째 방법은 User정보를 가지고 오는 부분에서 Method를 Post로 바꾸고 Body로 user정보를 넘기는 방법
- 2번째 방법은 UserId를 넘기지 말고 전체 유저를 가져와 그 유저 값에서 찾아 사용하는 방법입니다.
- 급한 문제였기에 우선 2번 문제로 해결하고 나주에 1번이나 더 좋은 방법으로 회의를 통해서 수정하면 좋을 거 같습니다