### PR TITLE
🔀 :: (#96) Feed 페이징 처리

### DIFF
--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
@@ -4,6 +4,7 @@ import com.xquare.v1servicefeed.annotation.Api;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryListResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
 import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
 
@@ -17,7 +18,7 @@ public interface FeedApi {
 
     void deleteFeedById(UUID feedId);
 
-    FeedListResponse getAllFeed(UUID categoryId, long limit, long page);
+    FeedListPageResponse getAllFeed(UUID categoryId, long limit, long page);
 
     FeedCategoryListResponse getAllCategory();
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
@@ -3,10 +3,7 @@ package com.xquare.v1servicefeed.feed.api;
 import com.xquare.v1servicefeed.annotation.Api;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryListResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.*;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -18,6 +15,8 @@ public interface FeedApi {
     void updateFeed(DomainUpdateFeedRequest request);
 
     void deleteFeedById(UUID feedId);
+
+    FeedWeakElement getFeed(UUID feedId);
 
     FeedListPageResponse getAllFeed(UUID categoryId, LocalDateTime dateTime, long limit);
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
@@ -17,7 +17,7 @@ public interface FeedApi {
 
     void deleteFeedById(UUID feedId);
 
-    FeedListResponse getAllFeed(UUID categoryId);
+    FeedListResponse getAllFeed(UUID categoryId, long limit, long page);
 
     FeedCategoryListResponse getAllCategory();
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/FeedApi.java
@@ -8,6 +8,7 @@ import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
 import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Api
@@ -18,7 +19,7 @@ public interface FeedApi {
 
     void deleteFeedById(UUID feedId);
 
-    FeedListPageResponse getAllFeed(UUID categoryId, long limit, long page);
+    FeedListPageResponse getAllFeed(UUID categoryId, LocalDateTime dateTime, long limit);
 
     FeedCategoryListResponse getAllCategory();
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedListPageResponse.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedListPageResponse.java
@@ -1,0 +1,15 @@
+package com.xquare.v1servicefeed.feed.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FeedListPageResponse {
+
+    private final List<FeedElement> feeds;
+    private final long page;
+    private final long totalPage;
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedListPageResponse.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedListPageResponse.java
@@ -10,6 +10,4 @@ import java.util.List;
 public class FeedListPageResponse {
 
     private final List<FeedElement> feeds;
-    private final long page;
-    private final long totalPage;
 }

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedPageList.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedPageList.java
@@ -9,5 +9,4 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FeedPageList {
     private final List<FeedList> feedLists;
-    private final long totalPage;
 }

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedPageList.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedPageList.java
@@ -1,0 +1,13 @@
+package com.xquare.v1servicefeed.feed.api.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class FeedPageList {
+    private final List<FeedList> feedLists;
+    private final long totalPage;
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedWeakElement.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/response/FeedWeakElement.java
@@ -1,0 +1,22 @@
+package com.xquare.v1servicefeed.feed.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class FeedWeakElement {
+
+    private final UUID feedId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final String profile;
+    private final String name;
+    private final String type;
+    private final List<String> attachmentsUrl;
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -24,6 +24,7 @@ import com.xquare.v1servicefeed.user.spi.FeedAuthoritySpi;
 import com.xquare.v1servicefeed.user.spi.FeedUserSpi;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class FeedApiImpl implements FeedApi {
     }
 
     @Override
-    public FeedListPageResponse getAllFeed(UUID categoryId, long limit, long page) {
+    public FeedListPageResponse getAllFeed(UUID categoryId, LocalDateTime dateTime, long limit) {
         List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
         Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
@@ -97,7 +98,7 @@ public class FeedApiImpl implements FeedApi {
         UUID currentUserId = securitySpi.getCurrentUserId();
         boolean isTest = isUserValidate();
 
-        FeedPageList feedPageList = queryFeedSpi.queryAllFeedByCategory(categoryId, limit, page);
+        FeedPageList feedPageList = queryFeedSpi.queryAllFeedByCategory(categoryId, dateTime, limit);
         List<FeedElement> feedList = feedPageList.getFeedLists()
                 .stream()
                 .filter(feed -> !isTest || !feed.getType().equals(UserAuthority.UKN.name()))
@@ -111,7 +112,7 @@ public class FeedApiImpl implements FeedApi {
                 })
                 .toList();
 
-        return new FeedListPageResponse(feedList, page, feedPageList.getTotalPage());
+        return new FeedListPageResponse(feedList);
     }
 
     @Override

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -9,13 +9,7 @@ import com.xquare.v1servicefeed.feed.Feed;
 import com.xquare.v1servicefeed.feed.api.FeedApi;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
-import com.xquare.v1servicefeed.feed.api.dto.response.AuthorityElement;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryElement;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryListResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedElement;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedList;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.*;
 import com.xquare.v1servicefeed.feed.spi.CommandFeedImageSpi;
 import com.xquare.v1servicefeed.feed.spi.CommandFeedSpi;
 import com.xquare.v1servicefeed.feed.spi.QueryCategorySpi;
@@ -95,7 +89,7 @@ public class FeedApiImpl implements FeedApi {
     }
 
     @Override
-    public FeedListResponse getAllFeed(UUID categoryId, long limit, long page) {
+    public FeedListPageResponse getAllFeed(UUID categoryId, long limit, long page) {
         List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
         Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
@@ -103,7 +97,8 @@ public class FeedApiImpl implements FeedApi {
         UUID currentUserId = securitySpi.getCurrentUserId();
         boolean isTest = isUserValidate();
 
-        List<FeedElement> feedList = queryFeedSpi.queryAllFeedByCategory(categoryId, limit, page)
+        FeedPageList feedPageList = queryFeedSpi.queryAllFeedByCategory(categoryId, limit, page);
+        List<FeedElement> feedList = feedPageList.getFeedLists()
                 .stream()
                 .filter(feed -> !isTest || !feed.getType().equals(UserAuthority.UKN.name()))
                 .map(feed -> {
@@ -116,7 +111,7 @@ public class FeedApiImpl implements FeedApi {
                 })
                 .toList();
 
-        return new FeedListResponse(feedList);
+        return new FeedListPageResponse(feedList, page, feedPageList.getTotalPage());
     }
 
     @Override

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -90,6 +90,22 @@ public class FeedApiImpl implements FeedApi {
     }
 
     @Override
+    public FeedWeakElement getFeed(UUID feedId) {
+        Feed feed = queryFeedSpi.queryFeedById(feedId);
+        UserAuthority userAuthority = UserAuthority.valueOf(feed.getType());
+        return FeedWeakElement.builder()
+                .createdAt(feed.getCreatedAt())
+                .attachmentsUrl(queryFeedImageSpi.queryAllAttachmentsUrl(feed.getId()))
+                .content(feed.getContent())
+                .feedId(feedId)
+                .name(userAuthority.getName())
+                .profile(userAuthority.getProfile())
+                .title(feed.getTitle())
+                .type(feed.getType())
+                .build();
+    }
+
+    @Override
     public FeedListPageResponse getAllFeed(UUID categoryId, LocalDateTime dateTime, long limit) {
         List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
         Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -95,7 +95,7 @@ public class FeedApiImpl implements FeedApi {
     }
 
     @Override
-    public FeedListResponse getAllFeed(UUID categoryId) {
+    public FeedListResponse getAllFeed(UUID categoryId, long limit, long page) {
         List<UUID> userIdList = queryFeedSpi.queryAllFeedUserIdByCategory(categoryId);
         Map<UUID, User> hashMap = feedUserSpi.queryUserByIds(userIdList).stream()
                 .collect(Collectors.toMap(User::getId, user -> user, (userId, user) -> user, HashMap::new));
@@ -103,7 +103,7 @@ public class FeedApiImpl implements FeedApi {
         UUID currentUserId = securitySpi.getCurrentUserId();
         boolean isTest = isUserValidate();
 
-        List<FeedElement> feedList = queryFeedSpi.queryAllFeedByCategory(categoryId)
+        List<FeedElement> feedList = queryFeedSpi.queryAllFeedByCategory(categoryId, limit, page)
                 .stream()
                 .filter(feed -> !isTest || !feed.getType().equals(UserAuthority.UKN.name()))
                 .map(feed -> {

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/spi/QueryFeedSpi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/spi/QueryFeedSpi.java
@@ -5,6 +5,7 @@ import com.xquare.v1servicefeed.feed.Feed;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedList;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedPageList;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,7 +13,7 @@ import java.util.UUID;
 public interface QueryFeedSpi {
     Feed queryFeedById(UUID feedId);
 
-    FeedPageList queryAllFeedByCategory(UUID categoryId, long limit, long page);
+    FeedPageList queryAllFeedByCategory(UUID categoryId, LocalDateTime time, long limit);
 
     List<UUID> queryAllFeedUserIdByCategory(UUID categoryId);
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/spi/QueryFeedSpi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/spi/QueryFeedSpi.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public interface QueryFeedSpi {
     Feed queryFeedById(UUID feedId);
 
-    List<FeedList> queryAllFeedByCategory(UUID categoryId);
+    List<FeedList> queryAllFeedByCategory(UUID categoryId, long limit, long page);
 
     List<UUID> queryAllFeedUserIdByCategory(UUID categoryId);
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/spi/QueryFeedSpi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/spi/QueryFeedSpi.java
@@ -3,6 +3,7 @@ package com.xquare.v1servicefeed.feed.spi;
 import com.xquare.v1servicefeed.annotation.Spi;
 import com.xquare.v1servicefeed.feed.Feed;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedList;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedPageList;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,7 +12,7 @@ import java.util.UUID;
 public interface QueryFeedSpi {
     Feed queryFeedById(UUID feedId);
 
-    List<FeedList> queryAllFeedByCategory(UUID categoryId, long limit, long page);
+    FeedPageList queryAllFeedByCategory(UUID categoryId, long limit, long page);
 
     List<UUID> queryAllFeedUserIdByCategory(UUID categoryId);
 

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepository.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepository.java
@@ -8,5 +8,4 @@ import java.util.UUID;
 
 @Repository
 public interface FeedRepository extends CrudRepository<FeedEntity, UUID> {
-    long countByCategoryEntity_Id(UUID id);
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepository.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepository.java
@@ -4,9 +4,9 @@ import com.xquare.v1servicefeed.feed.domain.FeedEntity;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface FeedRepository extends CrudRepository<FeedEntity, UUID> {
+    long countByCategoryEntity_Id(UUID id);
 }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
@@ -59,7 +59,7 @@ public class FeedRepositoryAdapter implements FeedSpi {
     }
 
     @Override
-    public List<FeedList> queryAllFeedByCategory(UUID categoryId) {
+    public List<FeedList> queryAllFeedByCategory(UUID categoryId, long limit, long page) {
         List<FeedListVO> voList = query
                 .select(new QFeedListVO(
                         feedEntity.id,
@@ -79,6 +79,8 @@ public class FeedRepositoryAdapter implements FeedSpi {
                 .where(categoryIdEq(categoryId))
                 .groupBy(feedEntity.id)
                 .orderBy(feedEntity.createdAt.desc())
+                .limit(limit)
+                .offset(limit * page)
                 .fetch();
 
         return voList.stream()
@@ -100,9 +102,7 @@ public class FeedRepositoryAdapter implements FeedSpi {
                 .selectFrom(feedEntity).distinct()
                 .leftJoin(feedLikeEntity)
                 .on(feedEntity.id.eq(feedLikeEntity.feedEntity.id))
-                .where(
-                        categoryIdEq(categoryId), feedEntity.type.eq("UKN").not()
-                )
+                .where(categoryIdEq(categoryId), feedEntity.type.eq("UKN").not())
                 .orderBy(feedEntity.createdAt.desc())
                 .fetch();
 

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
@@ -98,8 +98,7 @@ public class FeedRepositoryAdapter implements FeedSpi {
                         .likeCount(feedListVO.getLikeCount())
                         .commentCount(feedListVO.getCommentCount())
                         .build())
-                .collect(Collectors.toList()),
-                feedRepository.countByCategoryEntity_Id(categoryId) / limit
+                .collect(Collectors.toList())
         );
     }
 

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
@@ -3,16 +3,14 @@ package com.xquare.v1servicefeed.feed.web;
 import com.xquare.v1servicefeed.feed.api.FeedApi;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryListResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
-import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.*;
 import com.xquare.v1servicefeed.feed.web.dto.request.WebCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.web.dto.request.WebUpdateFeedRequest;
 import com.xquare.v1servicefeed.report.api.ReportApi;
 import com.xquare.v1servicefeed.report.api.dto.CreateReportDomainRequest;
 import com.xquare.v1servicefeed.report.web.dto.request.CreateReportWebRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -60,10 +58,17 @@ public class WebFeedAdapter {
         feedApi.deleteFeedById(feedId);
     }
 
+    @GetMapping("/{feed-uuid}")
+    public FeedWeakElement getFeed(
+            @PathVariable("feed-uuid") UUID feedId
+    ) {
+        return feedApi.getFeed(feedId);
+    }
+
     @GetMapping
     public FeedListPageResponse getAllFeed(
             @RequestParam(value = "category", required = false) UUID categoryId,
-            @RequestParam(required = false) LocalDateTime dateTime,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateTime,
             @RequestParam(defaultValue = "6") long limit
     ) {
         return feedApi.getAllFeed(categoryId, dateTime, limit);

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
@@ -1,5 +1,9 @@
 package com.xquare.v1servicefeed.feed.web;
 
+import com.xquare.v1servicefeed.feed.api.FeedImageApi;
+import com.xquare.v1servicefeed.feed.api.dto.request.CreateFeedImageRequest;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
+import com.xquare.v1servicefeed.feed.domain.repository.FeedRepository;
 import com.xquare.v1servicefeed.report.api.ReportApi;
 import com.xquare.v1servicefeed.report.api.dto.CreateReportDomainRequest;
 import com.xquare.v1servicefeed.report.web.dto.request.CreateReportWebRequest;
@@ -59,10 +63,10 @@ public class WebFeedAdapter {
     }
 
     @GetMapping
-    public FeedListResponse getAllFeed(
+    public FeedListPageResponse getAllFeed(
             @RequestParam(value = "category", required = false) UUID categoryId,
-            @RequestParam(defaultValue = "8") long limit,
-            @RequestParam(defaultValue = "0") long page
+            @RequestParam(defaultValue = "6") long limit,
+            @RequestParam(defaultValue = "1") long page
     ) {
         return feedApi.getAllFeed(categoryId, limit, page);
     }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
@@ -59,8 +59,12 @@ public class WebFeedAdapter {
     }
 
     @GetMapping
-    public FeedListResponse getAllFeed(@RequestParam(value = "category", required = false) UUID categoryId) {
-        return feedApi.getAllFeed(categoryId);
+    public FeedListResponse getAllFeed(
+            @RequestParam(value = "category", required = false) UUID categoryId,
+            @RequestParam(defaultValue = "8") long limit,
+            @RequestParam(defaultValue = "0") long page
+    ) {
+        return feedApi.getAllFeed(categoryId, limit, page);
     }
 
     @GetMapping("/category")

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/web/WebFeedAdapter.java
@@ -1,25 +1,23 @@
 package com.xquare.v1servicefeed.feed.web;
 
-import com.xquare.v1servicefeed.feed.api.FeedImageApi;
-import com.xquare.v1servicefeed.feed.api.dto.request.CreateFeedImageRequest;
-import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
-import com.xquare.v1servicefeed.feed.domain.repository.FeedRepository;
-import com.xquare.v1servicefeed.report.api.ReportApi;
-import com.xquare.v1servicefeed.report.api.dto.CreateReportDomainRequest;
-import com.xquare.v1servicefeed.report.web.dto.request.CreateReportWebRequest;
 import com.xquare.v1servicefeed.feed.api.FeedApi;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedCategoryListResponse;
+import com.xquare.v1servicefeed.feed.api.dto.response.FeedListPageResponse;
 import com.xquare.v1servicefeed.feed.api.dto.response.FeedListResponse;
 import com.xquare.v1servicefeed.feed.api.dto.response.SaveFeedResponse;
 import com.xquare.v1servicefeed.feed.web.dto.request.WebCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.web.dto.request.WebUpdateFeedRequest;
+import com.xquare.v1servicefeed.report.api.ReportApi;
+import com.xquare.v1servicefeed.report.api.dto.CreateReportDomainRequest;
+import com.xquare.v1servicefeed.report.web.dto.request.CreateReportWebRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -65,10 +63,10 @@ public class WebFeedAdapter {
     @GetMapping
     public FeedListPageResponse getAllFeed(
             @RequestParam(value = "category", required = false) UUID categoryId,
-            @RequestParam(defaultValue = "6") long limit,
-            @RequestParam(defaultValue = "1") long page
+            @RequestParam(required = false) LocalDateTime dateTime,
+            @RequestParam(defaultValue = "6") long limit
     ) {
-        return feedApi.getAllFeed(categoryId, limit, page);
+        return feedApi.getAllFeed(categoryId, dateTime, limit);
     }
 
     @GetMapping("/category")

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/user/domain/repository/UserRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/user/domain/repository/UserRepositoryAdapter.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -24,21 +23,25 @@ public class UserRepositoryAdapter implements FeedUserSpi, CommentUserSpi {
         if (ids.isEmpty()) {
             return List.of();
         }
-        List<UserInfoElement> userList = userClient.getUserInfo(ids).getUsers();
+        try {
+            List<UserInfoElement> userList = userClient.getUserInfo(ids).getUsers();
 
-        return userList.stream()
-                .map(userInfoElement -> User.builder()
-                        .id(userInfoElement.getId())
-                        .accountId(userInfoElement.getAccountId())
-                        .name(userInfoElement.getName())
-                        .password(userInfoElement.getPassword())
-                        .birthDay(userInfoElement.getBirthDay())
-                        .grade(userInfoElement.getGrade())
-                        .classNum(userInfoElement.getClassNum())
-                        .num(userInfoElement.getNum())
-                        .profileFileName(userInfoElement.getProfileFileName())
-                        .build())
-                .toList();
+            return userList.stream()
+                    .map(userInfoElement -> User.builder()
+                            .id(userInfoElement.getId())
+                            .accountId(userInfoElement.getAccountId())
+                            .name(userInfoElement.getName())
+                            .password(userInfoElement.getPassword())
+                            .birthDay(userInfoElement.getBirthDay())
+                            .grade(userInfoElement.getGrade())
+                            .classNum(userInfoElement.getClassNum())
+                            .num(userInfoElement.getNum())
+                            .profileFileName(userInfoElement.getProfileFileName())
+                            .build())
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
     }
 
     @Override


### PR DESCRIPTION
모든 피드를 불러오지 않고, 피드를 페이징 처리하여 한 번에 많은 데이터를 받아오지 않도록 변경
QueryDSL을 사용중이기에, limit, offset 추가 예정

- [x] 카테고리 별로 피드를 가져올 때 Limit & Offset 추가
- [x] 피드 API에 페이징 파라미터 추가
- [x] Frontend에도 적용할 수 있도록 API Response 변경