### PR TITLE
🔀 :: Application Event를 이용해 notification 분리

### DIFF
--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/dto/event/SaveCommentEvent.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/dto/event/SaveCommentEvent.java
@@ -1,0 +1,14 @@
+package com.xquare.v1servicefeed.comment.api.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class SaveCommentEvent {
+
+    private final UUID feedUserId;
+    private final UUID feedId;
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/comment/api/impl/CommentApiImpl.java
@@ -3,11 +3,13 @@ package com.xquare.v1servicefeed.comment.api.impl;
 import com.xquare.v1servicefeed.annotation.DomainService;
 import com.xquare.v1servicefeed.comment.Comment;
 import com.xquare.v1servicefeed.comment.api.CommentApi;
+import com.xquare.v1servicefeed.comment.api.dto.event.SaveCommentEvent;
 import com.xquare.v1servicefeed.comment.api.dto.request.CreateCommentDomainRequest;
 import com.xquare.v1servicefeed.comment.api.dto.request.UpdateCommentDomainRequest;
 import com.xquare.v1servicefeed.comment.api.dto.response.CommentDomainElement;
 import com.xquare.v1servicefeed.comment.spi.CommandCommentSpi;
 import com.xquare.v1servicefeed.comment.spi.QueryCommentSpi;
+import com.xquare.v1servicefeed.configuration.spi.EventPublisherSpi;
 import com.xquare.v1servicefeed.configuration.spi.SecuritySpi;
 import com.xquare.v1servicefeed.feed.Feed;
 import com.xquare.v1servicefeed.feed.spi.QueryFeedSpi;
@@ -34,9 +36,7 @@ public class CommentApiImpl implements CommentApi {
     private final CommandCommentSpi commandCommentSpi;
     private final QueryCommentSpi queryCommentSpi;
     private final SecuritySpi securitySpi;
-    private final NotificationSpi notificationSpi;
-    private static final String FEED_COMMENT = "FEED_COMMENT";
-    private static final String CONTENT = "댓글이 달렸습니다.";
+    private final EventPublisherSpi eventPublisherSpi;
 
     @Override
     public void saveComment(CreateCommentDomainRequest request) {
@@ -52,12 +52,7 @@ public class CommentApiImpl implements CommentApi {
                         .build()
         );
 
-        notificationSpi.sendNotification(
-                feed.getUserId(),
-                FEED_COMMENT,
-                CONTENT,
-                feed.getId().toString()
-        );
+        eventPublisherSpi.publishEvent(new SaveCommentEvent(feed.getUserId(), feed.getId()));
     }
 
     @Override

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/configuration/spi/EventPublisherSpi.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/configuration/spi/EventPublisherSpi.java
@@ -1,0 +1,6 @@
+package com.xquare.v1servicefeed.configuration.spi;
+
+public interface EventPublisherSpi {
+
+    void publishEvent(Object event);
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/event/SaveFeedEvent.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/dto/event/SaveFeedEvent.java
@@ -1,0 +1,11 @@
+package com.xquare.v1servicefeed.feed.api.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SaveFeedEvent {
+
+    private final String type;
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feed/api/impl/FeedApiImpl.java
@@ -7,17 +7,18 @@ import com.xquare.v1servicefeed.feed.Category;
 import com.xquare.v1servicefeed.feed.CategoryEnum;
 import com.xquare.v1servicefeed.feed.Feed;
 import com.xquare.v1servicefeed.feed.api.FeedApi;
+import com.xquare.v1servicefeed.feed.api.dto.event.SaveFeedEvent;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainCreateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.request.DomainUpdateFeedRequest;
 import com.xquare.v1servicefeed.feed.api.dto.response.*;
 import com.xquare.v1servicefeed.feed.spi.CommandFeedImageSpi;
 import com.xquare.v1servicefeed.feed.spi.CommandFeedSpi;
+import com.xquare.v1servicefeed.configuration.spi.EventPublisherSpi;
 import com.xquare.v1servicefeed.feed.spi.QueryCategorySpi;
 import com.xquare.v1servicefeed.feed.spi.QueryFeedImageSpi;
 import com.xquare.v1servicefeed.feed.spi.QueryFeedSpi;
 import com.xquare.v1servicefeed.feedlike.spi.CommandFeedLikeSpi;
 import com.xquare.v1servicefeed.feedlike.spi.QueryFeedLikeSpi;
-import com.xquare.v1servicefeed.notification.NotificationSpi;
 import com.xquare.v1servicefeed.user.User;
 import com.xquare.v1servicefeed.user.exception.InvalidRoleException;
 import com.xquare.v1servicefeed.user.role.UserAuthority;
@@ -47,10 +48,7 @@ public class FeedApiImpl implements FeedApi {
     private final QueryCategorySpi queryCategorySpi;
     private final CommandFeedLikeSpi commandFeedLikeSpi;
     private final FeedAuthoritySpi feedAuthoritySpi;
-    private final NotificationSpi notificationSpi;
-    private static final String FEED_NOTICE = "FEED_NOTICE";
-    private static final String CONTENT = "새로운 공지가 등록되었습니다.";
-    private static final String THREAD_ID = "FEED_NOTICE";
+    private final EventPublisherSpi eventPublisherSpi;
 
     @Override
     public SaveFeedResponse saveFeed(DomainCreateFeedRequest request) {
@@ -70,14 +68,7 @@ public class FeedApiImpl implements FeedApi {
                 .build();
 
         UUID feedId = commandFeedSpi.saveFeed(feed);
-
-        if ("DOS".equals(request.getType()) || "ADMIN".equals(request.getType())) {
-            notificationSpi.sendGroupNotification(
-                    FEED_NOTICE,
-                    CONTENT,
-                    THREAD_ID
-            );
-        }
+        eventPublisherSpi.publishEvent(new SaveFeedEvent(request.getType()));
         return new SaveFeedResponse(feedId);
     }
 

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feedlike/api/dto/event/SaveFeedLikeEvent.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feedlike/api/dto/event/SaveFeedLikeEvent.java
@@ -1,0 +1,14 @@
+package com.xquare.v1servicefeed.feedlike.api.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class SaveFeedLikeEvent {
+
+    private final UUID feedUserId;
+    private final UUID feedId;
+}

--- a/feed-domain/src/main/java/com/xquare/v1servicefeed/feedlike/api/impl/FeedLikeApiImpl.java
+++ b/feed-domain/src/main/java/com/xquare/v1servicefeed/feedlike/api/impl/FeedLikeApiImpl.java
@@ -1,11 +1,14 @@
 package com.xquare.v1servicefeed.feedlike.api.impl;
 
 import com.xquare.v1servicefeed.annotation.DomainService;
+import com.xquare.v1servicefeed.configuration.spi.EventPublisherSpi;
 import com.xquare.v1servicefeed.configuration.spi.SecuritySpi;
 import com.xquare.v1servicefeed.feed.Feed;
+import com.xquare.v1servicefeed.feed.api.dto.event.SaveFeedEvent;
 import com.xquare.v1servicefeed.feed.spi.QueryFeedSpi;
 import com.xquare.v1servicefeed.feedlike.FeedLike;
 import com.xquare.v1servicefeed.feedlike.api.FeedLikeApi;
+import com.xquare.v1servicefeed.feedlike.api.dto.event.SaveFeedLikeEvent;
 import com.xquare.v1servicefeed.feedlike.exception.FeedLikeExistsException;
 import com.xquare.v1servicefeed.feedlike.exception.FeedLikeNotFoundException;
 import com.xquare.v1servicefeed.feedlike.spi.CommandFeedLikeSpi;
@@ -22,7 +25,7 @@ public class FeedLikeApiImpl implements FeedLikeApi {
     private final QueryFeedSpi queryFeedSpi;
     private final QueryFeedLikeSpi queryFeedLikeSpi;
     private final SecuritySpi securitySpi;
-    private final NotificationSpi notificationSpi;
+    private final EventPublisherSpi eventPublisherSpi;
 
     @Override
     public void saveFeedLike(UUID feedId) {
@@ -40,12 +43,7 @@ public class FeedLikeApiImpl implements FeedLikeApi {
                         .build()
         );
 
-        notificationSpi.sendNotification(
-                feed.getUserId(),
-                "FEED_LIKE",
-                "좋아요가 달렸습니다.",
-                feed.getId().toString()
-        );
+        eventPublisherSpi.publishEvent(new SaveFeedLikeEvent(feed.getUserId(), feed.getId()));
     }
 
     @Override

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/domain/event/CommentEventListener.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/domain/event/CommentEventListener.java
@@ -1,0 +1,26 @@
+package com.xquare.v1servicefeed.comment.domain.event;
+
+import com.xquare.v1servicefeed.comment.api.dto.event.SaveCommentEvent;
+import com.xquare.v1servicefeed.notification.NotificationSpi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CommentEventListener {
+
+    private final NotificationSpi notificationSpi;
+    private static final String FEED_COMMENT = "FEED_COMMENT";
+    private static final String CONTENT = "댓글이 달렸습니다.";
+
+    @EventListener
+    public void onSaveComment(SaveCommentEvent event) {
+        notificationSpi.sendNotification(
+                event.getFeedUserId(),
+                FEED_COMMENT,
+                CONTENT,
+                event.getFeedId().toString()
+        );
+    }
+}

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/event/CommentEventListener.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/comment/event/CommentEventListener.java
@@ -1,4 +1,4 @@
-package com.xquare.v1servicefeed.comment.domain.event;
+package com.xquare.v1servicefeed.comment.event;
 
 import com.xquare.v1servicefeed.comment.api.dto.event.SaveCommentEvent;
 import com.xquare.v1servicefeed.notification.NotificationSpi;

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/configuration/event/EventPublisher.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/configuration/event/EventPublisher.java
@@ -1,0 +1,19 @@
+package com.xquare.v1servicefeed.configuration.event;
+
+import com.xquare.v1servicefeed.configuration.spi.EventPublisherSpi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class EventPublisher implements EventPublisherSpi {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publishEvent(Object event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+}

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/event/FeedEventListener.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/event/FeedEventListener.java
@@ -13,7 +13,6 @@ public class FeedEventListener {
     private final NotificationSpi notificationSpi;
     private static final String FEED_NOTICE = "FEED_NOTICE";
     private static final String CONTENT = "새로운 공지가 등록되었습니다.";
-    private static final String THREAD_ID = "FEED_NOTICE";
 
     @EventListener
     public void onSaveFeed(SaveFeedEvent event) {
@@ -21,7 +20,7 @@ public class FeedEventListener {
             notificationSpi.sendGroupNotification(
                     FEED_NOTICE,
                     CONTENT,
-                    THREAD_ID
+                    FEED_NOTICE
             );
         }
     }

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/event/FeedEventListener.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/event/FeedEventListener.java
@@ -1,0 +1,28 @@
+package com.xquare.v1servicefeed.feed.event;
+
+import com.xquare.v1servicefeed.feed.api.dto.event.SaveFeedEvent;
+import com.xquare.v1servicefeed.notification.NotificationSpi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class FeedEventListener {
+
+    private final NotificationSpi notificationSpi;
+    private static final String FEED_NOTICE = "FEED_NOTICE";
+    private static final String CONTENT = "새로운 공지가 등록되었습니다.";
+    private static final String THREAD_ID = "FEED_NOTICE";
+
+    @EventListener
+    public void onSaveFeed(SaveFeedEvent event) {
+        if ("DOS".equals(event.getType()) || "ADMIN".equals(event.getType())) {
+            notificationSpi.sendGroupNotification(
+                    FEED_NOTICE,
+                    CONTENT,
+                    THREAD_ID
+            );
+        }
+    }
+}

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/event/FeedLikeEventListener.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/event/FeedLikeEventListener.java
@@ -1,0 +1,24 @@
+package com.xquare.v1servicefeed.feedlike.event;
+
+import com.xquare.v1servicefeed.feedlike.api.dto.event.SaveFeedLikeEvent;
+import com.xquare.v1servicefeed.notification.NotificationSpi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class FeedLikeEventListener {
+
+    private final NotificationSpi notificationSpi;
+
+    @EventListener
+    public void onSaveFeedLike(SaveFeedLikeEvent event) {
+        notificationSpi.sendNotification(
+                event.getFeedUserId(),
+                "FEED_LIKE",
+                "좋아요가 달렸습니다.",
+                event.getFeedId().toString()
+        );
+    }
+}

--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/event/FeedLikeEventListener.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feedlike/event/FeedLikeEventListener.java
@@ -11,13 +11,15 @@ import org.springframework.stereotype.Component;
 public class FeedLikeEventListener {
 
     private final NotificationSpi notificationSpi;
+    private static final String TOPIC = "FEED_LIKE";
+    private static final String CONTENT = "좋아요가 달렸습니다.";
 
     @EventListener
     public void onSaveFeedLike(SaveFeedLikeEvent event) {
         notificationSpi.sendNotification(
                 event.getFeedUserId(),
-                "FEED_LIKE",
-                "좋아요가 달렸습니다.",
+                TOPIC,
+                CONTENT,
                 event.getFeedId().toString()
         );
     }


### PR DESCRIPTION
기존에는 Feed, FeedLike, Comment를 저장하는 save%에서 notificationSpi를 호출하여 알림을 전송했습니다.
이는 간단하고 직관적이지만 도메인적인 관점으로 보았을때 feed와 notification 도메인간의 결합도를 높히게 됩니다.
그리고 각각을 저장한다는 책임만을 가지고 있는 save% 메서드에 알림을 전송한다는 책임이 추가되게 됩니다.
이 문제점을 해결하기 위해 Spring의 Application Event를 사용하게 되었습니다.
Application Event는 각 listener들이 이벤트가 발생했는지 확인하고 발생하게 되면 메서드를 작동하게 됩니다.

각 save% 메서드들은 해당 메서드가 작동됬다는 Event만을 알리고,
그 Event가 작동되었을때 Listener에 있는 각 메서드들을 작동하여 알림을 전송하게 됩니다.