### PR TITLE
🔀 :: (#246) 댓글 갯수 오류 해결

### DIFF
--- a/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
+++ b/feed-infrastructure/src/main/java/com/xquare/v1servicefeed/feed/domain/repository/FeedRepositoryAdapter.java
@@ -81,7 +81,10 @@ public class FeedRepositoryAdapter implements FeedSpi {
                 .on(feedEntity.id.eq(feedLikeEntity.feedEntity.id))
                 .leftJoin(commentEntity)
                 .on(feedEntity.id.eq(commentEntity.feedEntity.id))
-                .where(expression.and(categoryIdEq(categoryId)), feedEntity.deleted.eq(false))
+                .where(
+                        commentEntity.deleted.eq(false),
+                        expression.and(categoryIdEq(categoryId)), feedEntity.deleted.eq(false)
+                )
                 .groupBy(feedEntity.id)
                 .orderBy(feedEntity.createdAt.desc())
                 .limit(limit)


### PR DESCRIPTION
- SoftDelete를 위해 만든 칼럼인 'deleted' 칼럼의 값이 false인 것만 가져오는 조건이 없어서 쿼리문에 해당 조건을 추가하였습니다.